### PR TITLE
Setting Amplify platform to WEB_COMPUTE for NEXTJS application support

### DIFF
--- a/lib/amplify/amplifyStack.ts
+++ b/lib/amplify/amplifyStack.ts
@@ -1,8 +1,7 @@
 import { Stack, StackProps, SecretValue } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { App, GitHubSourceCodeProvider } from '@aws-cdk/aws-amplify-alpha' 
+import { App, GitHubSourceCodeProvider, Platform } from '@aws-cdk/aws-amplify-alpha' 
 import { Config } from '../../bin/config';
-import { BuildSpec } from 'aws-cdk-lib/aws-codebuild';
 
 export class AmplifyStack extends Stack {
     constructor(scope: Construct, id: string, props?: StackProps) {
@@ -14,7 +13,8 @@ export class AmplifyStack extends Stack {
                 repository: Config.websiteGithubRepo,
                 oauthToken: SecretValue.secretsManager(Config.githubTokenKey)
             }),
-            appName: `${Config.websiteGithubRepo}-${getBranch(this.account)}`
+            appName: `${Config.websiteGithubRepo}-${getBranch(this.account)}`,
+            platform: Platform.WEB_COMPUTE
         });
 
         amplify.addBranch(getBranch(this.account));

--- a/test/amplify/amplifyStack.test.ts
+++ b/test/amplify/amplifyStack.test.ts
@@ -2,6 +2,7 @@ import { App } from "aws-cdk-lib";
 import { Config } from "../../bin/config";
 import { AmplifyStack } from "../../lib/amplify/amplifyStack";
 import { Template } from "aws-cdk-lib/assertions";
+import { Platform } from '@aws-cdk/aws-amplify-alpha' 
 
 const app = new App();
 
@@ -27,7 +28,8 @@ describe('Testing Amplify Stack', () => {
     test('Test Staging Amplify App', () => {
         stagingTemplate.hasResourceProperties('AWS::Amplify::App', {
             Repository: `https://github.com/${Config.websiteGithubOwner}/${Config.websiteGithubRepo}`,
-            OauthToken: `{{resolve:secretsmanager:${Config.githubTokenKey}:SecretString:::}}`
+            OauthToken: `{{resolve:secretsmanager:${Config.githubTokenKey}:SecretString:::}}`,
+            Platform: Platform.WEB_COMPUTE
         });
 
         stagingTemplate.hasResourceProperties('AWS::Amplify::Branch', {
@@ -38,7 +40,8 @@ describe('Testing Amplify Stack', () => {
     test('Test Prod Amplify App', () => {
         prodTemplate.hasResourceProperties('AWS::Amplify::App', {
             Repository: `https://github.com/${Config.websiteGithubOwner}/${Config.websiteGithubRepo}`,
-            OauthToken: `{{resolve:secretsmanager:${Config.githubTokenKey}:SecretString:::}}`
+            OauthToken: `{{resolve:secretsmanager:${Config.githubTokenKey}:SecretString:::}}`,
+            Platform: Platform.WEB_COMPUTE
         });
 
         prodTemplate.hasResourceProperties('AWS::Amplify::Branch', {


### PR DESCRIPTION
Adding `WEB_COMPUTE` as the Amplify App platform to support NEXTJS application builds