### PR TITLE
Removing platform configuration for Amplify stack. UI is switching to Vite instead of NextJS

### DIFF
--- a/lib/amplify/amplifyStack.ts
+++ b/lib/amplify/amplifyStack.ts
@@ -13,8 +13,7 @@ export class AmplifyStack extends Stack {
                 repository: Config.websiteGithubRepo,
                 oauthToken: SecretValue.secretsManager(Config.githubTokenKey)
             }),
-            appName: `${Config.websiteGithubRepo}-${getBranch(this.account)}`,
-            platform: Platform.WEB_COMPUTE
+            appName: `${Config.websiteGithubRepo}-${getBranch(this.account)}`
         });
 
         amplify.addBranch(getBranch(this.account));

--- a/test/amplify/amplifyStack.test.ts
+++ b/test/amplify/amplifyStack.test.ts
@@ -28,8 +28,7 @@ describe('Testing Amplify Stack', () => {
     test('Test Staging Amplify App', () => {
         stagingTemplate.hasResourceProperties('AWS::Amplify::App', {
             Repository: `https://github.com/${Config.websiteGithubOwner}/${Config.websiteGithubRepo}`,
-            OauthToken: `{{resolve:secretsmanager:${Config.githubTokenKey}:SecretString:::}}`,
-            Platform: Platform.WEB_COMPUTE
+            OauthToken: `{{resolve:secretsmanager:${Config.githubTokenKey}:SecretString:::}}`
         });
 
         stagingTemplate.hasResourceProperties('AWS::Amplify::Branch', {
@@ -40,8 +39,7 @@ describe('Testing Amplify Stack', () => {
     test('Test Prod Amplify App', () => {
         prodTemplate.hasResourceProperties('AWS::Amplify::App', {
             Repository: `https://github.com/${Config.websiteGithubOwner}/${Config.websiteGithubRepo}`,
-            OauthToken: `{{resolve:secretsmanager:${Config.githubTokenKey}:SecretString:::}}`,
-            Platform: Platform.WEB_COMPUTE
+            OauthToken: `{{resolve:secretsmanager:${Config.githubTokenKey}:SecretString:::}}`
         });
 
         prodTemplate.hasResourceProperties('AWS::Amplify::Branch', {


### PR DESCRIPTION
Removing platform configuration for Amplify Stack since we are switching from NextJS to Vite. 

Amplify console is failing with following error otherwise
```
 [ERROR]: !!! CustomerError: Failed to find the deploy-manifest.json file in the build output. Please verify that it exists within the "baseDirectory" specified in your buildSpec. If it's not there, we will also check the .amplify-hosting directory as a fallback. When using a framework adapter for hosting on Amplify, double-check that the adapter settings are correct.
```