### PR TITLE
Adding Route53 Stack to create hosted zones

### DIFF
--- a/bin/config.ts
+++ b/bin/config.ts
@@ -6,5 +6,7 @@ export const Config = {
     githubRepo: 'W0nyoung/CapitolHillCleaningEmporiumCDK',
     websiteGithubRepo: 'CapitolHillCleaningEmporiumUI',
     websiteGithubOwner: 'tyrakrehbiel',
-    githubTokenKey: 'GitHubToken'
+    githubTokenKey: 'GitHubToken',
+    rootLevelDomain: 'capitolhillcleaningemporium.com',
+    rootHostedZoneID: 'Z08291237IFX56AZ3TA8'
 }

--- a/lib/pipeline/pipelineStage.ts
+++ b/lib/pipeline/pipelineStage.ts
@@ -1,11 +1,13 @@
 import { Stage, StageProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { AmplifyStack } from '../amplify/amplifyStack';
+import { Route53Stack } from '../route53/route53Stack';
 
 export class PipelineStage extends Stage {
     constructor(scope: Construct, id: string, props?: StageProps) {
         super(scope, id, props);
 
-        new AmplifyStack(this, `AmplifyStack-${this.account}`);
+        const amplifyStack = new AmplifyStack(this, `AmplifyStack-${this.account}`);
+        amplifyStack.addDependency(new Route53Stack(this, `Route53Stack-${this.account}`));
     };
 };

--- a/lib/route53/route53Stack.ts
+++ b/lib/route53/route53Stack.ts
@@ -1,0 +1,55 @@
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Config } from '../../bin/config';
+import { PublicHostedZone } from 'aws-cdk-lib/aws-route53';
+import { AccountPrincipal, Effect, PolicyDocument, PolicyStatement, Role } from 'aws-cdk-lib/aws-iam';
+
+export class Route53Stack extends Stack {
+    constructor(scope: Construct, id: string, props?: StackProps) {
+        super(scope, id, props);
+        
+        if (this.account === Config.prodAccount) {
+            const rootZone = new PublicHostedZone(this, `PublicHostedZone-${Config.rootLevelDomain}`, {
+                zoneName: Config.rootLevelDomain
+            });
+
+            const crossAccountRole = new Role(this, 'CrossAccountRole', {
+                roleName: 'Route53CrossAccountDelegationRole',
+                assumedBy: new AccountPrincipal(Config.stagingAccount),
+                inlinePolicies: {
+                  crossAccountPolicy: new PolicyDocument({
+                    statements: [
+                      new PolicyStatement({
+                        sid: 'ListHostedZonesByName',
+                        effect: Effect.ALLOW,
+                        actions: ['route53:ListHostedZonesByName'],
+                        resources: ['*'],
+                      }),
+                      new PolicyStatement({
+                        sid: 'GetHostedZoneAndChangeResourceRecordSets',
+                        effect: Effect.ALLOW,
+                        actions: ['route53:GetHostedZone', 'route53:ChangeResourceRecordSets'],
+                        resources: [`arn:aws:route53:::hostedzone/${Config.rootHostedZoneID}`],
+                        conditions: {
+                          'ForAllValues:StringLike': {
+                            'route53:ChangeResourceRecordSetsNormalizedRecordNames': [
+                              `staging.${Config.rootLevelDomain}`,
+                            ],
+                          },
+                        },
+                      }),
+                    ],
+                  }),
+                },
+              });
+
+              rootZone.grantDelegation(crossAccountRole);
+        } else {
+            const subZone = new PublicHostedZone(this, `PublicHostedZone-staging.${Config.rootLevelDomain}`, {
+                zoneName: `staging.${Config.rootLevelDomain}`
+            });
+
+            // Todo: Create Cross Account Zone delegation
+        }
+    };
+};

--- a/test/pipeline/pipelineStage.test.ts
+++ b/test/pipeline/pipelineStage.test.ts
@@ -16,29 +16,47 @@ const template = Template.fromStack(stack);
 
 describe('Testing PipelineStage Stack', () => {
 
-    test('Staging stage has Amplify Stack', () => {
-        template.hasResourceProperties('AWS::CodePipeline::Pipeline', {
-            Stages: Match.arrayWith([Match.objectLike({
-              Name: 'StagingAccountStage',
-              Actions: Match.arrayWith([Match.objectLike({
+  test('Staging stage has Stacks in Correct Order', () => {
+    template.hasResourceProperties('AWS::CodePipeline::Pipeline', {
+        Stages: Match.arrayWith([
+          Match.objectLike({
+            Name: 'StagingAccountStage',
+            Actions: Match.arrayWith([
+              Match.objectLike({
+                Configuration: Match.objectLike({
+                  StackName: Match.stringLikeRegexp('StagingAccountStage-Route53Stack-*')
+                })
+              }),
+              Match.objectLike({
                 Configuration: Match.objectLike({
                   StackName: Match.stringLikeRegexp('StagingAccountStage-AmplifyStack-*')
                 })
-              })])
-            })])
-        });
+              })
+            ])
+          })
+        ])
+      });
     });
 
-    test('Prod stage has Amplify Stack', () => {
-        template.hasResourceProperties('AWS::CodePipeline::Pipeline', {
-            Stages: Match.arrayWith([Match.objectLike({
-              Name: 'ProdAccountStage',
-              Actions: Match.arrayWith([Match.objectLike({
+  test('Prod stage has Stacks in Correct Order', () => {
+    template.hasResourceProperties('AWS::CodePipeline::Pipeline', {
+        Stages: Match.arrayWith([
+          Match.objectLike({
+            Name: 'ProdAccountStage',
+            Actions: Match.arrayWith([
+              Match.objectLike({
+                Configuration: Match.objectLike({
+                  StackName: Match.stringLikeRegexp('ProdAccountStage-Route53Stack-*')
+                })
+              }),
+              Match.objectLike({
                 Configuration: Match.objectLike({
                   StackName: Match.stringLikeRegexp('ProdAccountStage-AmplifyStack-*')
                 })
-              })])
-            })])
-        });
+              })
+            ])
+          })
+        ])
+      });
     });
 });

--- a/test/route53/route53Stack.test.ts
+++ b/test/route53/route53Stack.test.ts
@@ -1,0 +1,63 @@
+import { App } from "aws-cdk-lib";
+import { Route53Stack } from "../../lib/route53/route53Stack";
+import { Config } from "../../bin/config";
+import { Match, Template } from "aws-cdk-lib/assertions";
+
+const app = new App();
+
+const stagingStack = new Route53Stack(app, 'StagingRoute53Stack', {
+    env: {
+        account: Config.stagingAccount,
+        region: Config.region,
+      }
+});
+
+const prodStack = new Route53Stack(app, 'ProdRoute53Stack', {
+    env: {
+        account: Config.prodAccount,
+        region: Config.region,
+      }
+});
+
+const stagingTemplate = Template.fromStack(stagingStack);
+const prodTemplate = Template.fromStack(prodStack);
+
+describe('Testing Route53 Stack', () => {
+    test('Test Staging Route53 Stack', () => {
+        stagingTemplate.hasResourceProperties('AWS::Route53::HostedZone', {
+            Name: `staging.${Config.rootLevelDomain}.`
+        });
+
+        stagingTemplate.resourceCountIs('AWS::IAM::Role', 0);
+    });
+
+    test('Test Prod Route53 Stack', () => {
+        prodTemplate.hasResourceProperties('AWS::Route53::HostedZone', {
+            Name: `${Config.rootLevelDomain}.`
+        });
+
+        prodTemplate.hasResourceProperties('AWS::IAM::Role', {
+            RoleName: 'Route53CrossAccountDelegationRole',
+            AssumeRolePolicyDocument: {
+                Statement: Match.arrayWith([
+                    Match.objectLike({
+                        Principal: {
+                            AWS: {
+                                'Fn::Join': [
+                                    '', 
+                                    [
+                                        'arn:',
+                                        {
+                                            'Ref': 'AWS::Partition'
+                                        },
+                                        `:iam::${Config.stagingAccount}:root`
+                                    ]
+                                ]
+                            }
+                        }
+                    })
+                ])
+            }
+        });
+    });
+});


### PR DESCRIPTION
Adding Route53 stack to create hosted zone for prod and staging

Root level domain: `capitolhillcleaningemporium.com`

Route53 stack will be a dependency of the AmplifyStack

Will need to add cross account delegation to create NS relationship between prod and staging in next pull request