### PR TITLE
Updating Prod Route53 stack to lookup existing Public Hosted Zone instead of creating new one. Added JSDocs

### DIFF
--- a/lib/amplify/amplifyStack.ts
+++ b/lib/amplify/amplifyStack.ts
@@ -3,6 +3,11 @@ import { Construct } from 'constructs';
 import { App, GitHubSourceCodeProvider, Platform } from '@aws-cdk/aws-amplify-alpha' 
 import { Config } from '../../bin/config';
 
+/**
+ * Amplify CDK Stack
+ * Creates Amplify App in each account referencing respective GitHub branch depending on stage
+ * GitHub token for UI Repo is stored in AWS Secrets Manager in each account
+ */
 export class AmplifyStack extends Stack {
     constructor(scope: Construct, id: string, props?: StackProps) {
         super(scope, id, props);

--- a/lib/pipeline/pipelineStack.ts
+++ b/lib/pipeline/pipelineStack.ts
@@ -4,6 +4,12 @@ import { CodePipeline, CodePipelineSource, ShellStep } from 'aws-cdk-lib/pipelin
 import { Config } from '../../bin/config';
 import { PipelineStage } from './pipelineStage';
 
+/**
+ * AWS CodePipeline CDK Stack
+ * GitHub Token for CDK Repo is stored in AWS Secrets Manager
+ * Pipeline tracks main branch and will deploy changes whenever a change is pushed to main
+ * Pipeline stages, staging and prod, are defined here
+ */
 export class PipelineStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);

--- a/lib/pipeline/pipelineStage.ts
+++ b/lib/pipeline/pipelineStage.ts
@@ -3,6 +3,11 @@ import { Construct } from 'constructs';
 import { AmplifyStack } from '../amplify/amplifyStack';
 import { Route53Stack } from '../route53/route53Stack';
 
+/**
+ * AWS CodePipeline CDK Stack
+ * Creates a stage for staging and prod
+ * CDK Stacks and their dependency relationships are defined here
+ */
 export class PipelineStage extends Stage {
     constructor(scope: Construct, id: string, props?: StageProps) {
         super(scope, id, props);

--- a/lib/route53/route53Stack.ts
+++ b/lib/route53/route53Stack.ts
@@ -1,17 +1,25 @@
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Config } from '../../bin/config';
-import { PublicHostedZone } from 'aws-cdk-lib/aws-route53';
+import { HostedZone, PublicHostedZone } from 'aws-cdk-lib/aws-route53';
 import { AccountPrincipal, Effect, PolicyDocument, PolicyStatement, Role } from 'aws-cdk-lib/aws-iam';
 
+/**
+ * Route53 CDK Stack for creating Route53 Public Hosted Zones
+ * Used to manage website DNS configuration
+ * Root hosted zone is created automatically by Route53 when domain was registered
+ */
 export class Route53Stack extends Stack {
     constructor(scope: Construct, id: string, props?: StackProps) {
         super(scope, id, props);
         
         if (this.account === Config.prodAccount) {
-            const rootZone = new PublicHostedZone(this, `PublicHostedZone-${Config.rootLevelDomain}`, {
-                zoneName: Config.rootLevelDomain
-            });
+              /**
+             * Prod DNS configuration
+             * References root hosted zone through zone ID
+             * Creates an IAM role for staging account to assume in order to create NS, subdomain, relationship in Prod Hosted Zone
+             */
+            const rootZone = HostedZone.fromHostedZoneId(this, `PublicHostedZone-${Config.rootLevelDomain}`, Config.rootHostedZoneID);
 
             const crossAccountRole = new Role(this, 'CrossAccountRole', {
                 roleName: 'Route53CrossAccountDelegationRole',
@@ -43,8 +51,12 @@ export class Route53Stack extends Stack {
                 },
               });
 
-              rootZone.grantDelegation(crossAccountRole);
+              rootZone.grantDelegation(crossAccountRole);     
         } else {
+            /**
+             * Staging DNS configuration
+             * Creates Hosted Zone in Staging account
+             */
             const subZone = new PublicHostedZone(this, `PublicHostedZone-staging.${Config.rootLevelDomain}`, {
                 zoneName: `staging.${Config.rootLevelDomain}`
             });

--- a/test/route53/route53Stack.test.ts
+++ b/test/route53/route53Stack.test.ts
@@ -32,10 +32,6 @@ describe('Testing Route53 Stack', () => {
     });
 
     test('Test Prod Route53 Stack', () => {
-        prodTemplate.hasResourceProperties('AWS::Route53::HostedZone', {
-            Name: `${Config.rootLevelDomain}.`
-        });
-
         prodTemplate.hasResourceProperties('AWS::IAM::Role', {
             RoleName: 'Route53CrossAccountDelegationRole',
             AssumeRolePolicyDocument: {


### PR DESCRIPTION
AWS Route53 automatically creates a hosted zone for us when we register a domain 

Removing Prod Hosted Zone creation and instead referencing existing Public Hosted Zone

Added JSDocs